### PR TITLE
fix(prettier): use same `printWidth` as `max-len`

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -263,6 +263,6 @@ module.exports = {
     'import/no-amd': ['error'],
     'import/no-commonjs': ['error'],
     'import/no-extraneous-dependencies': ['error'],
-    'prettier/prettier': ['error', { trailingComma: 'es5', singleQuote: true }],
+    'prettier/prettier': ['error', { trailingComma: 'es5', singleQuote: true, printWidth: 120 }],
   },
 };

--- a/rules.js
+++ b/rules.js
@@ -164,7 +164,7 @@ module.exports = {
     'max-len': [
       'error',
       {
-        code: 120,
+        code: 80,
         ignoreComments: true,
         ignoreTrailingComments: true,
         ignoreUrls: true,
@@ -263,6 +263,9 @@ module.exports = {
     'import/no-amd': ['error'],
     'import/no-commonjs': ['error'],
     'import/no-extraneous-dependencies': ['error'],
-    'prettier/prettier': ['error', { trailingComma: 'es5', singleQuote: true, printWidth: 120 }],
+    'prettier/prettier': [
+      'error',
+      { trailingComma: 'es5', singleQuote: true, printWidth: 80 },
+    ],
   },
 };

--- a/sample-project/src/connect.js
+++ b/sample-project/src/connect.js
@@ -3,7 +3,8 @@ import shallowCompare from 'react-addons-shallow-compare';
 
 import storeShape from './storeShape.js';
 
-const getDisplayName = WrappedComponent => WrappedComponent.displayName || WrappedComponent.name || 'UnknownComponent';
+const getDisplayName = WrappedComponent =>
+  WrappedComponent.displayName || WrappedComponent.name || 'UnknownComponent';
 
 export default function connect(mapStateToProps) {
   return WrappedComponent =>
@@ -18,7 +19,9 @@ export default function connect(mapStateToProps) {
           this.state = mapStateToProps(context.algoliaStore.getState(), props);
 
           this.unsubscribe = context.algoliaStore.subscribe(() => {
-            this.setState(mapStateToProps(context.algoliaStore.getState(), this.props));
+            this.setState(
+              mapStateToProps(context.algoliaStore.getState(), this.props)
+            );
           });
         }
       }
@@ -30,7 +33,9 @@ export default function connect(mapStateToProps) {
       }
 
       componentWillReceiveProps(nextProps) {
-        this.setState(mapStateToProps(this.context.algoliaStore.getState(), nextProps));
+        this.setState(
+          mapStateToProps(this.context.algoliaStore.getState(), nextProps)
+        );
       }
 
       shouldComponentUpdate(nextProps, nextState) {
@@ -38,7 +43,13 @@ export default function connect(mapStateToProps) {
       }
 
       render() {
-        return <WrappedComponent {...this.props} {...this.state} helper={this.context.algoliaStore.getHelper()} />;
+        return (
+          <WrappedComponent
+            {...this.props}
+            {...this.state}
+            helper={this.context.algoliaStore.getHelper()}
+          />
+        );
       }
     };
 }

--- a/sample-project/src/connect.js
+++ b/sample-project/src/connect.js
@@ -3,8 +3,7 @@ import shallowCompare from 'react-addons-shallow-compare';
 
 import storeShape from './storeShape.js';
 
-const getDisplayName = WrappedComponent =>
-  WrappedComponent.displayName || WrappedComponent.name || 'UnknownComponent';
+const getDisplayName = WrappedComponent => WrappedComponent.displayName || WrappedComponent.name || 'UnknownComponent';
 
 export default function connect(mapStateToProps) {
   return WrappedComponent =>
@@ -19,9 +18,7 @@ export default function connect(mapStateToProps) {
           this.state = mapStateToProps(context.algoliaStore.getState(), props);
 
           this.unsubscribe = context.algoliaStore.subscribe(() => {
-            this.setState(
-              mapStateToProps(context.algoliaStore.getState(), this.props)
-            );
+            this.setState(mapStateToProps(context.algoliaStore.getState(), this.props));
           });
         }
       }
@@ -33,9 +30,7 @@ export default function connect(mapStateToProps) {
       }
 
       componentWillReceiveProps(nextProps) {
-        this.setState(
-          mapStateToProps(this.context.algoliaStore.getState(), nextProps)
-        );
+        this.setState(mapStateToProps(this.context.algoliaStore.getState(), nextProps));
       }
 
       shouldComponentUpdate(nextProps, nextState) {
@@ -43,13 +38,7 @@ export default function connect(mapStateToProps) {
       }
 
       render() {
-        return (
-          <WrappedComponent
-            {...this.props}
-            {...this.state}
-            helper={this.context.algoliaStore.getHelper()}
-          />
-        );
+        return <WrappedComponent {...this.props} {...this.state} helper={this.context.algoliaStore.getHelper()} />;
       }
     };
 }


### PR DESCRIPTION
eslint & prettier were not enforcing the same line length, now they have the same line limit to 120 characters.