### PR TITLE
fix(eslint): disable `no-duplicate-imports`

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -235,7 +235,7 @@ module.exports = {
     'no-confusing-arrow': ['off'],
     'no-const-assign': ['error'],
     'no-dupe-class-members': ['error'],
-    'no-duplicate-imports': ['error'],
+    'no-duplicate-imports': ['off'],
     'no-new-symbol': ['error'],
     'no-restricted-imports': ['off'],
     'no-this-before-super': ['error'],
@@ -263,6 +263,7 @@ module.exports = {
     'import/no-amd': ['error'],
     'import/no-commonjs': ['error'],
     'import/no-extraneous-dependencies': ['error'],
+    'import/no-duplicates': ['error'],
     'prettier/prettier': ['error', { trailingComma: 'es5', singleQuote: true }],
   },
 };


### PR DESCRIPTION
If you import libdef for flow you will get a warning of duplicate import, the rule `no-duplicate-imports` does not supports flow but `import/no-duplicates` does.

Failing code which is correct as example:

```javascript
import { action, observable } from 'mobx';
import type { ObservableArray } from 'mobx';
```

Original issue on eslint open here https://github.com/babel/eslint-plugin-babel/issues/59