### PR TITLE
chore(release): allow beta

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+## Contibuting
+
+### Test
+
+We have a [sample-project](sample-project).
+
+```sh
+yarn test
+```
+
+### Release
+
+> note: don't use `yarn` for releasing, it does not have access to the npm credentials
+
+```sh
+npm run release
+```

--- a/README.md
+++ b/README.md
@@ -242,22 +242,6 @@ Also activate "Lint HTML files" when dealing with `.vue` components.
 
 See "Ignoring Files and Directories" on [ESLint website](http://eslint.org/docs/user-guide/configuring.html#ignoring-files-and-directories).
 
-## Contibuting
-
-### Test
-
-We have a [sample-project](sample-project).
-
-```sh
-yarn test
-```
-
-### Release
-
-```sh
-npm run release
-```
-
 [version-svg]: https://img.shields.io/npm/v/eslint-config-algolia.svg?style=flat-square
 [package-url]: https://npmjs.org/package/eslint-config-algolia
 [travis-svg]: https://img.shields.io/travis/algolia/eslint-config-algolia/master.svg?style=flat-square

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -41,7 +41,8 @@ read -p "=> Release: press [ENTER] to view changes since latest version.."
 conventional-changelog --preset angular --output-unreleased | less
 
 # choose and bump new version
-# printf "\n\nRelease: Please enter the new chosen version > "
+printf "\n=> Release: please type the new tag (latest or beta)> "
+read -e npm_tag
 printf "\n=> Release: please type the new chosen version > "
 read -e newVersion
 
@@ -70,7 +71,7 @@ printf "\n\nRelease: push to github, publish on npm\n"
 git push origin master
 git push origin --tags
 
-npm publish
+npm publish --tag="${npm_tag}"
 
 printf "\n\nRelease:
 Package was published to npm.\n\n"


### PR DESCRIPTION
This is slightly different than in react-instantsearch, because a new prompt is easier to remember than a tag to add