### PR TITLE
chore: fix renovate preset

### DIFF
--- a/sample-project/package.json
+++ b/sample-project/package.json
@@ -18,7 +18,7 @@
   },
   "renovate": {
     "extends": [
-      ":lib"
+      "config:base"
     ],
     "semanticCommits": true,
     "rebaseStalePrs": true,


### PR DESCRIPTION
`":lib"` does not exist, you probably intended `":library"`. However I have deprecated that now in favour of `"config:*"` presets. As you have pinned version numbers in all dependency types here, the most appropriate is `"config:base"`.