### PR TITLE
feat: enable curly rules

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -42,7 +42,7 @@ module.exports = {
     'class-methods-use-this': ['off'],
     complexity: ['error'],
     'consistent-return': ['error'],
-    curly: ['off'],
+    curly: ['error'],
     'default-case': ['error'],
     'dot-location': ['off'],
     'dot-notation': ['error'],


### PR DESCRIPTION
We discuss a bit about that in routing PR of InstantSearch (I didn't find where, the PR is a bit large).

Enable the `curly` rule to his default value which is [`all`](https://eslint.org/docs/rules/curly#all).