### PR TITLE
feat(base): allow unused var with rest

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -120,7 +120,7 @@ module.exports = {
     'no-shadow-restricted-names': ['error'],
     'no-undef': ['error'],
     'no-undefined': ['off'],
-    'no-unused-vars': ['error'],
+    'no-unused-vars': ['error', { ignoreRestSiblings: true }],
     'no-use-before-define': ['error', { functions: false }],
 
     // Node.js and Common.js


### PR DESCRIPTION
**Summary**

This rule allow to easily omit values from an object.

> https://eslint.org/docs/rules/no-unused-vars#ignorerestsiblings

```js
const sample = {
  value: "hello",
  omit: "world"
};

const render = ({ omit, ...rest }) => {
  console.log(rest); // { value: 'hello' }
};
```