### PR TITLE
feat(import): enforce no extensions for js files

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -261,6 +261,7 @@ module.exports = {
     'import/no-commonjs': ['error'],
     'import/no-extraneous-dependencies': ['error'],
     'import/no-duplicates': ['error'],
+    'import/extensions': [2, 'always', { js: 'never' }],
     'prettier/prettier': [
       'error',
       { trailingComma: 'es5', singleQuote: true, printWidth: 80 },

--- a/sample-project/index.js
+++ b/sample-project/index.js
@@ -1,4 +1,4 @@
-import connect from './src/connect.js';
-import Provider from './src/Provider.js';
+import connect from './src/connect';
+import Provider from './src/Provider';
 
 export { Provider, connect };

--- a/sample-project/src/Provider.js
+++ b/sample-project/src/Provider.js
@@ -1,8 +1,8 @@
 import { Component, Children } from 'react';
 import PropTypes from 'prop-types';
 
-import createStore from './createStore.js';
-import storeShape from './storeShape.js';
+import createStore from './createStore';
+import storeShape from './storeShape';
 
 class Provider extends Component {
   static propTypes = {

--- a/sample-project/src/connect.js
+++ b/sample-project/src/connect.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 
-import storeShape from './storeShape.js';
+import storeShape from './storeShape';
 
 const getDisplayName = WrappedComponent =>
   WrappedComponent.displayName || WrappedComponent.name || 'UnknownComponent';


### PR DESCRIPTION
As reported by @samouss we lack consistency in projects for extensions when importing files. Some projects suffers more from it than others (eg. instantsearch.js).

This rules forces to remove the extensions when importing js files.

Those were valide before:
```js
import lib from './lib.js';
import lib2 from './otherLib';
```

Now:
```js
import lib from './lib.js'; // 🙅‍♂️
import lib2 from './otherLib'; //  ✅
```

Related to https://github.com/algolia/instantsearch.js/pull/3022