### PR TITLE
feat(rules): disable @typescript-eslint/explicit-function-return-type

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -8,13 +8,7 @@ module.exports = {
     '@typescript-eslint/ban-ts-ignore': ['off'],
     '@typescript-eslint/camelcase': ['error'],
     '@typescript-eslint/class-name-casing': ['error'],
-    '@typescript-eslint/explicit-function-return-type': [
-      'error',
-      {
-        allowExpressions: true,
-        allowTypedFunctionExpressions: true,
-      },
-    ],
+    '@typescript-eslint/explicit-function-return-type': ['off'],
     '@typescript-eslint/explicit-member-accessibility': ['error'],
     '@typescript-eslint/generic-type-naming': ['error', '^T[A-Z][a-zA-Z]+$'],
     '@typescript-eslint/indent': ['off'],


### PR DESCRIPTION
As discussed in the team,  while being useful to add explicitness and avoid some implicit `any`, the `@typescript-eslint/explicit-function-return-type` rule (added in https://github.com/algolia/eslint-config-algolia/pull/106) also adds some unwanted verbosity, can break inferred types if misused and the more we type our code the less it become useful (less implicit `any` to catch).

For these reasons we decided to disable it.