### PR TITLE
feat(typescript): allow unused vars starting with underscores

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -42,6 +42,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': [
       'error',
       {
+        argsIgnorePattern: '^_',
         ignoreRestSiblings: true,
       },
     ],


### PR DESCRIPTION
## Description

Keeping an unused variable in a function signature is sometimes useful to know what data we're dealing with. A common pattern is to prefix this variable with `_` to make it explicit that it's not used but it's usable. This pattern is used in the InstantSearch codebases.

This rule is already used in the [InstantSearch.js ESLint configuration](https://github.com/algolia/instantsearch.js/blob/b6ee2596d353ea692d91929759bc2b2fe34945c7/.eslintrc.js#L9-L12).

## Examples

```ts
function example(start: number): number[] {
  const values = ['a', 'b', 'c'];

  return values.map((_, index) => start + index);
}
```