### PR TITLE
feat(ts): compat for typescript-eslint 2

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -12,8 +12,8 @@ module.exports = {
       'error',
       {
         assertionStyle: 'as',
-        objectLiteralTypeAssertions: 'allow-as-parameter'
-      }
+        objectLiteralTypeAssertions: 'allow-as-parameter',
+      },
     ],
     '@typescript-eslint/explicit-function-return-type': ['off'],
     '@typescript-eslint/explicit-member-accessibility': ['error'],

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -3,11 +3,18 @@ module.exports = {
   plugins: ['@typescript-eslint'],
   rules: {
     '@typescript-eslint/adjacent-overload-signatures': ['error'],
-    '@typescript-eslint/array-type': ['error', 'array-simple'],
+    '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
     '@typescript-eslint/ban-types': ['error'],
     '@typescript-eslint/ban-ts-ignore': ['off'],
     '@typescript-eslint/camelcase': ['error'],
     '@typescript-eslint/class-name-casing': ['error'],
+    '@typescript-eslint/consistent-type-assertions': [
+      'error',
+      {
+        assertionStyle: 'as',
+        objectLiteralTypeAssertions: 'allow-as-parameter'
+      }
+    ],
     '@typescript-eslint/explicit-function-return-type': ['off'],
     '@typescript-eslint/explicit-member-accessibility': ['error'],
     '@typescript-eslint/generic-type-naming': ['error', '^T[A-Z][a-zA-Z]+$'],
@@ -21,7 +28,6 @@ module.exports = {
         default: ['static-field'],
       },
     ],
-    '@typescript-eslint/no-angle-bracket-type-assertion': ['error'],
     '@typescript-eslint/no-array-constructor': ['error'],
     '@typescript-eslint/no-empty-interface': ['error'],
     '@typescript-eslint/no-explicit-any': ['off'],
@@ -31,7 +37,6 @@ module.exports = {
     '@typescript-eslint/no-misused-new': ['error'],
     '@typescript-eslint/no-namespace': ['error'],
     '@typescript-eslint/no-non-null-assertion': ['off'],
-    '@typescript-eslint/no-object-literal-type-assertion': ['off'],
     '@typescript-eslint/no-parameter-properties': ['off'],
     '@typescript-eslint/no-require-imports': ['off'],
     '@typescript-eslint/no-this-alias': ['off'],


### PR DESCRIPTION
I based my changes on https://github.com/xojs/eslint-config-xo-typescript/commit/1053f6b449440985a7f07d4dfc237440c52a3503

and the changelog: https://github.com/typescript-eslint/typescript-eslint/blob/master/CHANGELOG.md#200-2019-08-13

fixes #113

This doesn't seem to be tested anywhere, so :fingers_crossed: haha

BREAKING CHANGE: /typescript requires typescript-eslint v2 now