### PR TITLE
feat(typescript): allow generic names starting with "K"

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -17,7 +17,10 @@ module.exports = {
     ],
     '@typescript-eslint/explicit-function-return-type': ['off'],
     '@typescript-eslint/explicit-member-accessibility': ['error'],
-    '@typescript-eslint/generic-type-naming': ['error', '^T[A-Z][a-zA-Z]+$'],
+    '@typescript-eslint/generic-type-naming': [
+      'error',
+      '^(T|K)[A-Z][a-zA-Z]+$',
+    ],
     '@typescript-eslint/indent': ['off'],
     '@typescript-eslint/interface-name-prefix': ['error', 'never'],
     '@typescript-eslint/member-delimiter-style': ['off'],


### PR DESCRIPTION
## Description

We accept only generic type names starting with "T" but sometimes, accepting "K" also makes sense. This is the case when using the TypeScript keyword `keyof`:

```ts
type StateToWidgets = {
  [KParameter in keyof IndexUiState]: Array<Widget['$$type']>;
};
```


## Related

- `keyof` feature: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-1.html#example
- Original need: https://github.com/algolia/instantsearch.js/pull/4140#discussion_r327328222