### PR TITLE
feat: add eslint-plugin-eslint-comments plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ yarn add \
 eslint babel-eslint prettier \
 eslint-config-algolia eslint-config-prettier \
 eslint-plugin-import eslint-plugin-prettier \
+eslint-plugin-eslint-comments \
 --dev
 ```
 

--- a/base.js
+++ b/base.js
@@ -20,7 +20,7 @@ module.exports = {
     './rules/base.js',
     'prettier',
   ],
-  plugins: ['import', 'prettier'],
+  plugins: ['eslint-comments', 'import', 'prettier'],
   settings: {
     'import/extensions': ['.js'],
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint": "5.16.0",
     "eslint-config-algolia": "10.1.0",
     "eslint-config-prettier": "6.4.0",
+    "eslint-plugin-eslint-comments": "3.1.2",
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-jest": "21.27.2",
     "eslint-plugin-prettier": "2.7.0",

--- a/rules/base.js
+++ b/rules/base.js
@@ -257,6 +257,15 @@ module.exports = {
     'template-curly-spacing': ['error'],
     'yield-star-spacing': ['error'],
 
+    // Comments
+    // https://mysticatea.github.io/eslint-plugin-eslint-comments
+    'eslint-comments/disable-enable-pair': ['error'],
+    'eslint-comments/no-aggregating-enable': ['error'],
+    'eslint-comments/no-duplicate-disable': ['error'],
+    'eslint-comments/no-unlimited-disable': ['error'],
+    'eslint-comments/no-unused-disable': ['error'],
+    'eslint-comments/no-unused-enable': ['error'],
+
     // Import
     // https://github.com/benmosher/eslint-plugin-import
     'import/no-amd': ['error'],

--- a/sample-project/package.json
+++ b/sample-project/package.json
@@ -21,6 +21,7 @@
     "eslint": "5.16.0",
     "eslint-config-algolia": "file:../",
     "eslint-config-prettier": "6.4.0",
+    "eslint-plugin-eslint-comments": "3.1.2",
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-jest": "21.27.2",
     "eslint-plugin-prettier": "2.7.0",

--- a/sample-project/yarn.lock
+++ b/sample-project/yarn.lock
@@ -433,6 +433,14 @@ eslint-module-utils@^2.4.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
+eslint-plugin-eslint-comments@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.1.2.tgz#4ef6c488dbe06aa1627fea107b3e5d059fc8a395"
+  integrity sha512-QexaqrNeteFfRTad96W+Vi4Zj1KFbkHHNMMaHZEYcovKav6gdomyGzaxSDSL3GoIyUOo078wRAdYlu1caiauIQ==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^5.0.5"
+
 eslint-plugin-import@2.18.2:
   version "2.18.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz#02f1180b90b077b33d447a17a2326ceb400aceb6"
@@ -786,6 +794,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.0.5:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
+  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
 import-fresh@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -907,6 +907,14 @@ eslint-module-utils@^2.4.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
+eslint-plugin-eslint-comments@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.1.2.tgz#4ef6c488dbe06aa1627fea107b3e5d059fc8a395"
+  integrity sha512-QexaqrNeteFfRTad96W+Vi4Zj1KFbkHHNMMaHZEYcovKav6gdomyGzaxSDSL3GoIyUOo078wRAdYlu1caiauIQ==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^5.0.5"
+
 eslint-plugin-import@2.18.2:
   version "2.18.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz#02f1180b90b077b33d447a17a2326ceb400aceb6"
@@ -1489,6 +1497,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.0.5:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
+  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
 import-fresh@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Fixes #112

This change adds the [eslint-plugin-eslint-comments](https://mysticatea.github.io/eslint-plugin-eslint-comments/) plugin to the `base` configuration.

All rules from the [Best Practices](https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/#best-practices) section are enabled.

This is a **breaking change** since the configuration requires a new peerDependency.
