### PR TITLE
feat(typescript): add support for @typescript-eslint/eslint-plugin 3.x

### DIFF
--- a/base.js
+++ b/base.js
@@ -22,6 +22,6 @@ module.exports = {
   ],
   plugins: ['eslint-comments', 'import', 'prettier'],
   settings: {
-    'import/extensions': ['.js'],
+    'import/extensions': ['.js', '.jsx', '.ts', '.tsx'],
   },
 };

--- a/rules/base.js
+++ b/rules/base.js
@@ -277,6 +277,9 @@ module.exports = {
       'ignorePackages',
       {
         js: 'never',
+        jsx: 'never',
+        ts: 'never',
+        tsx: 'never',
       },
     ],
 

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -5,9 +5,28 @@ module.exports = {
     '@typescript-eslint/adjacent-overload-signatures': ['error'],
     '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
     '@typescript-eslint/ban-types': ['error'],
-    '@typescript-eslint/ban-ts-ignore': ['off'],
-    '@typescript-eslint/camelcase': ['error'],
-    '@typescript-eslint/class-name-casing': ['error'],
+    '@typescript-eslint/ban-ts-comment': ['off'],
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'variable',
+        format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+        leadingUnderscore: 'allow',
+      },
+      {
+        selector: 'typeParameter',
+        format: ['PascalCase'],
+        prefix: ['T', 'K'],
+      },
+      {
+        selector: 'interface',
+        format: ['PascalCase'],
+        custom: {
+          regex: '^I[A-Z]',
+          match: false,
+        },
+      },
+    ],
     '@typescript-eslint/consistent-type-assertions': [
       'error',
       {
@@ -17,14 +36,8 @@ module.exports = {
     ],
     '@typescript-eslint/explicit-function-return-type': ['off'],
     '@typescript-eslint/explicit-member-accessibility': ['error'],
-    '@typescript-eslint/generic-type-naming': [
-      'error',
-      '^(T|K)[A-Z][a-zA-Z]+$',
-    ],
     '@typescript-eslint/indent': ['off'],
-    '@typescript-eslint/interface-name-prefix': ['error', 'never'],
     '@typescript-eslint/member-delimiter-style': ['off'],
-    '@typescript-eslint/member-naming': ['off'],
     '@typescript-eslint/member-ordering': [
       'error',
       {
@@ -59,7 +72,7 @@ module.exports = {
     '@typescript-eslint/no-var-requires': ['off'],
     '@typescript-eslint/prefer-for-of': ['off'],
     '@typescript-eslint/prefer-function-type': ['error'],
-    '@typescript-eslint/prefer-interface': ['off'],
+    '@typescript-eslint/consistent-type-definitions': ['off'],
     '@typescript-eslint/prefer-namespace-keyword': ['error'],
     '@typescript-eslint/promise-function-async': ['off'],
     '@typescript-eslint/restrict-plus-operands': ['off'],


### PR DESCRIPTION
This PR update the TypeScript rules to support [`@typescript-eslint/eslint-plugin`](https://github.com/typescript-eslint/typescript-eslint) 3.x

You can read the full changelog for 3.0.0 here: https://github.com/typescript-eslint/typescript-eslint/releases/tag/v3.0.0

This is a breaking change since this config will now require `@typescript-eslint/eslint-plugin` 3.x and will not work anymore with 1.x or 2.x

