### PR TITLE
fix: remove private-abstract-* options from member-ordering

### DIFF
--- a/packages/eslint-config-algolia/rules/typescript.js
+++ b/packages/eslint-config-algolia/rules/typescript.js
@@ -95,7 +95,6 @@ module.exports = {
 
           'public-abstract-field',
           'protected-abstract-field',
-          'private-abstract-field',
 
           'public-field',
           'protected-field',
@@ -119,7 +118,6 @@ module.exports = {
 
           'public-abstract-method',
           'protected-abstract-method',
-          'private-abstract-method',
 
           'public-method',
           'protected-method',


### PR DESCRIPTION
The config fails with recent versions of `typescript-eslint` with the following error (visible here: https://github.com/algolia/renderscript/pull/693):

```
Error: .eslintrc.js » eslint-config-algolia/typescript » ./rules/typescript.js:
	Configuration for rule "@typescript-eslint/member-ordering" is invalid:
	Value ["public-static-field","protected-static-field","private-static-field","public-instance-field","protected-instance-field","private-instance-field","public-abstract-field","protected-abstract-field","private-abstract-field","public-field","protected-field","private-field","static-field","instance-field","abstract-field","field","constructor","public-static-method","protected-static-method","private-static-method","public-instance-method","protected-instance-method","private-instance-method","public-abstract-method","protected-abstract-method","private-abstract-method","public-method","protected-method","private-method","static-method","instance-method","abstract-method","method","signature"] should be string.
	Value ["public-static-field","protected-static-field","private-static-field","public-instance-field","protected-instance-field","private-instance-field","public-abstract-field","protected-abstract-field","private-abstract-field","public-field","protected-field","private-field","static-field","instance-field","abstract-field","field","constructor","public-static-method","protected-static-method","private-static-method","public-instance-method","protected-instance-method","private-instance-method","public-abstract-method","protected-abstract-method","private-abstract-method","public-method","protected-method","private-method","static-method","instance-method","abstract-method","method","signature"] should be equal to one of the allowed values.
	Value "private-abstract-field" should be equal to one of the allowed values.
	Value "private-abstract-field" should be array.
	Value "private-abstract-field" should match exactly one schema in oneOf.
	Value ["public-static-field","protected-static-field","private-static-field","public-instance-field","protected-instance-field","private-instance-field","public-abstract-field","protected-abstract-field","private-abstract-field","public-field","protected-field","private-field","static-field","instance-field","abstract-field","field","constructor","public-static-method","protected-static-method","private-static-method","public-instance-method","protected-instance-method","private-instance-method","public-abstract-method","protected-abstract-method","private-abstract-method","public-method","protected-method","private-method","static-method","instance-method","abstract-method","method","signature"] should be object.
	Value ["public-static-field","protected-static-field","private-static-field","public-instance-field","protected-instance-field","private-instance-field","public-abstract-field","protected-abstract-field","private-abstract-field","public-field","protected-field","private-field","static-field","instance-field","abstract-field","field","constructor","public-static-method","protected-static-method","private-static-method","public-instance-method","protected-instance-method","private-instance-method","public-abstract-method","protected-abstract-method","private-abstract-method","public-method","protected-method","private-method","static-method","instance-method","abstract-method","method","signature"] should match exactly one schema in oneOf.
```

When looking at the doc (https://typescript-eslint.io/rules/member-ordering/), I don't see any `private-abstract-*` members anymore.
Removing them fixes the issue.