### PR TITLE
fix: release script should update yarn.lock

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -25,11 +25,11 @@ if [[ -n $(git status --porcelain) ]]; then
   exit 1
 fi
 
-printf "\n\nRelease: update working tree"
+printf "\n\nRelease: update working tree\n"
 git pull origin master
 git fetch origin --tags
 
-printf "Release: yarn"
+printf "Release: yarn\n"
 yarn
 
 
@@ -63,6 +63,9 @@ cd ../test
 yarn add --dev eslint-config-algolia@"$newVersion"
 cd ../..
 npm version "$newVersion" --no-git-tag-version
+
+# update yarn.lock
+yarn
 
 # update changelog
 printf "\n\nRelease: update changelog"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3110,7 +3110,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-algolia@20.1.0, eslint-config-algolia@workspace:packages/eslint-config-algolia":
+"eslint-config-algolia@21.0.0, eslint-config-algolia@workspace:packages/eslint-config-algolia":
   version: 0.0.0-use.local
   resolution: "eslint-config-algolia@workspace:packages/eslint-config-algolia"
   dependencies:
@@ -7365,7 +7365,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 5.5.0
     "@typescript-eslint/parser": 5.5.0
     eslint: 8.3.0
-    eslint-config-algolia: 20.1.0
+    eslint-config-algolia: 21.0.0
     jest: 27.4.2
     prop-types: 15.7.2
     react: 17.0.2


### PR DESCRIPTION
The release script wasn't updating the `yarn.lock` after bumping the version, that's why CI is failing after releasing: https://app.circleci.com/pipelines/github/algolia/eslint-config-algolia/1049/workflows/1eeeda3e-db30-48ed-9ced-1819a54a1d62/jobs/1046