### PR TITLE
feat: introduce flat config

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ module.exports = {
 };
 ```
 
+**eslint.config.js**
+```js
+const algolia = require('eslint-config-algolia/flat/base');
+module.exports = [
+  ...algolia,
+];
+```
+
 **package.json**
 ```json
 {
@@ -86,6 +94,16 @@ module.exports = {
 };
 ```
 
+**eslint.config.js**
+```js
+const algolia = require('eslint-config-algolia/flat/base');
+const algoliaJest = require('eslint-config-algolia/flat/jest');
+module.exports = [
+  ...algolia,
+  ...algoliaJest,
+];
+```
+
 **package.json**
 ```json
 {
@@ -111,6 +129,16 @@ module.exports = {
 };
 ```
 
+**eslint.config.js**
+```js
+const algolia = require('eslint-config-algolia/flat/base');
+const algoliaReact = require('eslint-config-algolia/flat/react');
+module.exports = [
+  ...algolia,
+  ...algoliaReact,
+];
+```
+
 **package.json**
 ```json
 {
@@ -122,7 +150,7 @@ module.exports = {
 }
 ```
 
-### Flow
+### Flow (deprecated)
 
 **terminal**
 ```sh
@@ -136,7 +164,7 @@ module.exports = {
 };
 ```
 
-### Flow with React
+### Flow with React (deprecated)
 
 **terminal**
 ```sh
@@ -171,12 +199,29 @@ yarn add @typescript-eslint/parser @typescript-eslint/eslint-plugin typescript -
 **.eslintrc.js**
 ```js
 module.exports = {
-  extends: ['algolia', 'algolia/typescript']
+  extends: ['algolia', 'algolia/typescript'],
 
   parserOptions: {
     project: '<path-to-tsconfig.json>',
   },
 };
+```
+
+**eslint.config.js**
+```js
+const algolia = require('eslint-config-algolia/flat/base');
+const algoliaTypescript = require('eslint-config-algolia/flat/typescript');
+module.exports = [
+  ...algolia,
+  ...algoliaTypescript,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: '<path-to-tsconfig.json>',
+      },
+    },
+  },
+];
 ```
 
 **package.json**
@@ -207,6 +252,18 @@ module.exports = {
 ```
 **Note**: Be sure to put the `algolia/typescript` configuration last so the parser is properly set for TypeScript files.
 
+**eslint.config.js**
+```js
+const algolia = require('eslint-config-algolia/flat/base');
+const algoliaReact = require('eslint-config-algolia/flat/react');
+const algoliaTypescript = require('eslint-config-algolia/flat/typescript');
+module.exports = [
+  ...algolia,
+  ...algoliaReact,
+  ...algoliaTypescript,
+];
+```
+
 **package.json**
 ```json
 {
@@ -231,6 +288,16 @@ yarn add eslint-plugin-vue --dev
 module.exports = {
   extends: ['algolia', 'algolia/vue']
 };
+```
+
+**eslint.config.js**
+```js
+const algolia = require('eslint-config-algolia/flat/base');
+const algoliaVue = require('eslint-config-algolia/flat/vue');
+module.exports = [
+  ...algolia,
+  ...algoliaVue,
+];
 ```
 
 **package.json**
@@ -275,8 +342,21 @@ module.exports = {
   extends: 'algolia',
   rules: {
     'import/no-commonjs': 'off'
-  }
+  },
 };
+```
+
+**eslint.config.js**
+```js
+const algolia = require('eslint-config-algolia/flat/base');
+module.exports = [
+  ...algolia,
+  {
+    rules: {
+      'import/no-commonjs': 'off'
+    }
+  },
+];
 ```
 
 ## Existing codebase setup

--- a/packages/eslint-config-algolia/.eslintrc.js
+++ b/packages/eslint-config-algolia/.eslintrc.js
@@ -1,4 +1,0 @@
-// eslint-disable-next-line import/no-commonjs
-module.exports = {
-  extends: './base.js',
-};

--- a/packages/eslint-config-algolia/eslint.config.js
+++ b/packages/eslint-config-algolia/eslint.config.js
@@ -1,0 +1,4 @@
+/* eslint-disable import/no-commonjs */
+const base = require('./flat/base');
+
+module.exports = [...base];

--- a/packages/eslint-config-algolia/flat/base.js
+++ b/packages/eslint-config-algolia/flat/base.js
@@ -1,0 +1,61 @@
+/* eslint-disable import/no-commonjs */
+const eslintJs = require('@eslint/js');
+const commentsPlugin = require('@eslint-community/eslint-plugin-eslint-comments');
+const stylisticPlugin = require('@stylistic/eslint-plugin');
+const importPlugin = require('eslint-plugin-import');
+const jsdocPlugin = require('eslint-plugin-jsdoc');
+const eslintPluginPrettierRecommended = require('eslint-plugin-prettier/recommended');
+const reactHooksPlugin = require('eslint-plugin-react-hooks');
+const globals = require('globals');
+
+const rules = require('../rules/base');
+
+// Remove legacy properties
+delete rules.overrides;
+
+module.exports = [
+  eslintJs.configs.recommended,
+  rules,
+  // prettier is set after to override our own rules
+  eslintPluginPrettierRecommended,
+  {
+    plugins: {
+      '@stylistic': stylisticPlugin,
+      '@eslint-community/eslint-comments': commentsPlugin,
+      import: importPlugin,
+      jsdoc: jsdocPlugin,
+      'react-hooks': reactHooksPlugin,
+    },
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: {
+          experimentalObjectRestSpread: true,
+          impliedStrict: true,
+        },
+      },
+    },
+    settings: {
+      'import/extensions': ['.js', '.jsx', '.ts', '.tsx'],
+
+      'import/resolver': {
+        node: {
+          extensions: ['.js', '.jsx', '.ts', '.tsx'],
+        },
+      },
+    },
+  },
+  // Mixed codebase issues
+  {
+    // enable the rule specifically for TypeScript files
+    files: ['*.ts', '*.tsx'],
+    rules: {
+      'jsdoc/no-types': ['error'],
+    },
+  },
+];

--- a/packages/eslint-config-algolia/flat/base.js
+++ b/packages/eslint-config-algolia/flat/base.js
@@ -50,10 +50,9 @@ module.exports = [
       },
     },
   },
-  // Mixed codebase issues
   {
     // enable the rule specifically for TypeScript files
-    files: ['*.ts', '*.tsx'],
+    files: ['**/*.ts', '**/*.tsx'],
     rules: {
       'jsdoc/no-types': ['error'],
     },

--- a/packages/eslint-config-algolia/flat/jest.js
+++ b/packages/eslint-config-algolia/flat/jest.js
@@ -1,0 +1,18 @@
+/* eslint-disable import/no-commonjs */
+const jestPlugin = require('eslint-plugin-jest');
+const globals = require('globals');
+
+const jestRules = require('../rules/jest');
+
+module.exports = [
+  jestRules,
+  {
+    ...jestPlugin.configs['flat/recommended'],
+    ...jestPlugin.configs['flat/style'],
+    languageOptions: {
+      globals: {
+        ...globals.jest,
+      },
+    },
+  },
+];

--- a/packages/eslint-config-algolia/flat/react.js
+++ b/packages/eslint-config-algolia/flat/react.js
@@ -8,7 +8,10 @@ const rules = require('../rules/react');
 
 module.exports = [
   reactPlugin.configs.flat.recommended,
+  rules,
   {
+    files: ['**/*.{js,mjs,cjs,jsx,mjsx,ts,tsx,mtsx}'],
+
     plugins: {
       'react-hooks': reactHooksPlugin,
       'jsx-a11y': jsxA11yPlugin,
@@ -24,5 +27,4 @@ module.exports = [
       },
     },
   },
-  rules,
 ];

--- a/packages/eslint-config-algolia/flat/react.js
+++ b/packages/eslint-config-algolia/flat/react.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-commonjs */
-const babelParser = require('@babel/eslint-parser');
 const jsxA11yPlugin = require('eslint-plugin-jsx-a11y');
 const reactPlugin = require('eslint-plugin-react');
 const reactHooksPlugin = require('eslint-plugin-react-hooks');
@@ -18,7 +17,6 @@ module.exports = [
     },
 
     languageOptions: {
-      parser: babelParser,
       parserOptions: {
         ecmaFeatures: {
           jsx: true,

--- a/packages/eslint-config-algolia/flat/react.js
+++ b/packages/eslint-config-algolia/flat/react.js
@@ -1,0 +1,28 @@
+/* eslint-disable import/no-commonjs */
+const babelParser = require('@babel/eslint-parser');
+const jsxA11yPlugin = require('eslint-plugin-jsx-a11y');
+const reactPlugin = require('eslint-plugin-react');
+const reactHooksPlugin = require('eslint-plugin-react-hooks');
+
+const rules = require('../rules/react');
+
+module.exports = [
+  reactPlugin.configs.flat.recommended,
+  {
+    plugins: {
+      'react-hooks': reactHooksPlugin,
+      'jsx-a11y': jsxA11yPlugin,
+    },
+
+    languageOptions: {
+      parser: babelParser,
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+        requireConfigFile: false,
+      },
+    },
+  },
+  rules,
+];

--- a/packages/eslint-config-algolia/flat/typescript.js
+++ b/packages/eslint-config-algolia/flat/typescript.js
@@ -29,10 +29,9 @@ module.exports = [
       },
     },
   },
-  // Mixed codebase issues
   {
     // enable the rule specifically for TypeScript files
-    files: ['*.ts', '*.tsx'],
+    files: ['**/*.ts', '**/*.tsx'],
     rules: {
       '@typescript-eslint/explicit-function-return-type': [
         'error',

--- a/packages/eslint-config-algolia/flat/typescript.js
+++ b/packages/eslint-config-algolia/flat/typescript.js
@@ -1,0 +1,48 @@
+/* eslint-disable import/no-commonjs */
+const typescriptPlugin = require('@typescript-eslint/eslint-plugin');
+const parser = require('@typescript-eslint/parser');
+const importPlugin = require('eslint-plugin-import');
+
+const rules = require('../rules/typescript');
+
+// Remove legacy properties
+delete rules.plugins;
+delete rules.overrides;
+
+module.exports = [
+  rules,
+  {
+    plugins: {
+      '@typescript-eslint': typescriptPlugin,
+      import: importPlugin,
+    },
+    languageOptions: {
+      parser,
+      parserOptions: {
+        ecmaFeatures: {
+          impliedStrict: true,
+          jsx: true,
+        },
+        ecmaVersion: 2018,
+        sourceType: 'module',
+        requireConfigFile: false,
+      },
+    },
+  },
+  // Mixed codebase issues
+  {
+    // enable the rule specifically for TypeScript files
+    files: ['*.ts', '*.tsx'],
+    rules: {
+      '@typescript-eslint/explicit-function-return-type': [
+        'error',
+        {
+          allowHigherOrderFunctions: true,
+          allowTypedFunctionExpressions: true,
+          // allowExpressions: true,
+        },
+      ],
+      '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
+    },
+  },
+];

--- a/packages/eslint-config-algolia/flat/vue.js
+++ b/packages/eslint-config-algolia/flat/vue.js
@@ -1,0 +1,40 @@
+// We don't extends from the `base` preset because the Vue plugin needs
+// to use the parser under `parserOptions`. By doing this we broke the import
+// plugin in the `react` preset. For now we just recreate the same configuration
+// until all the plugins behave the same.
+
+/* eslint-disable import/no-commonjs */
+const babelParser = require('@babel/eslint-parser');
+const importPlugin = require('eslint-plugin-import');
+const vuePlugin = require('eslint-plugin-vue');
+const globals = require('globals');
+
+const rules = require('../rules/vue');
+
+module.exports.flat = [
+  ...vuePlugin.configs['flat/recommended'],
+  rules,
+  {
+    plugins: {
+      import: importPlugin,
+    },
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+      ecmaVersion: 2018,
+      sourceType: 'module',
+      parser: babelParser, // allows both flowtype and static class properties
+      parserOptions: {
+        ecmaFeatures: {
+          impliedStrict: true,
+          jsx: true,
+        },
+      },
+    },
+    settings: {
+      'import/extensions': ['.js'],
+    },
+  },
+];

--- a/packages/eslint-config-algolia/package.json
+++ b/packages/eslint-config-algolia/package.json
@@ -27,6 +27,7 @@
     "@babel/core": "7.25.2",
     "@babel/eslint-parser": "7.25.1",
     "@eslint-community/eslint-plugin-eslint-comments": "4.4.0",
+    "@eslint/js": "9.11.1",
     "@stylistic/eslint-plugin": "2.7.2",
     "eslint": "8.57.0",
     "eslint-config-prettier": "8.10.0",
@@ -37,6 +38,7 @@
     "eslint-plugin-prettier": "5.2.1",
     "eslint-plugin-react": "7.35.0",
     "eslint-plugin-react-hooks": "4.6.2",
+    "globals": "15.10.0",
     "prettier": "3.3.3"
   },
   "peerDependencies": {

--- a/packages/eslint-config-algolia/package.json
+++ b/packages/eslint-config-algolia/package.json
@@ -31,7 +31,7 @@
     "@stylistic/eslint-plugin": "2.7.2",
     "eslint": "8.57.0",
     "eslint-config-prettier": "8.10.0",
-    "eslint-plugin-import": "2.29.1",
+    "eslint-plugin-import": "2.31.0",
     "eslint-plugin-jest": "28.8.2",
     "eslint-plugin-jsdoc": "50.2.2",
     "eslint-plugin-jsx-a11y": "6.9.0",

--- a/packages/test/eslint.config.js
+++ b/packages/test/eslint.config.js
@@ -6,8 +6,8 @@ const algoliaTypescript = require('eslint-config-algolia/flat/typescript');
 
 module.exports = [
   ...algolia,
-  ...algoliaReact,
   ...algoliaTypescript,
+  ...algoliaReact,
   ...algoliaJest,
   {
     languageOptions: {

--- a/packages/test/eslint.config.js
+++ b/packages/test/eslint.config.js
@@ -10,10 +10,6 @@ module.exports = [
   ...algoliaTypescript,
   ...algoliaJest,
   {
-    rules: {
-      // Re-enable when this is released: https://github.com/import-js/eslint-plugin-import/commit/186f248357437ef46889f3eab7fda8e6030ba874
-      'import/no-named-as-default': 'off',
-    },
     languageOptions: {
       parserOptions: {
         project: 'tsconfig.json',

--- a/packages/test/eslint.config.js
+++ b/packages/test/eslint.config.js
@@ -1,0 +1,23 @@
+/* eslint-disable import/no-commonjs, @typescript-eslint/no-var-requires */
+const algolia = require('eslint-config-algolia/flat/base');
+const algoliaJest = require('eslint-config-algolia/flat/jest');
+const algoliaReact = require('eslint-config-algolia/flat/react');
+const algoliaTypescript = require('eslint-config-algolia/flat/typescript');
+
+module.exports = [
+  ...algolia,
+  ...algoliaReact,
+  ...algoliaTypescript,
+  ...algoliaJest,
+  {
+    rules: {
+      // Re-enable when this is released: https://github.com/import-js/eslint-plugin-import/commit/186f248357437ef46889f3eab7fda8e6030ba874
+      'import/no-named-as-default': 'off',
+    },
+    languageOptions: {
+      parserOptions: {
+        project: 'tsconfig.json',
+      },
+    },
+  },
+];

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
+    "lint:legacy": "ESLINT_USE_FLAT_CONFIG=false eslint .",
     "lint:fix": "eslint . --fix"
   },
   "author": "Algolia <support@algolia.com> (https://github.com/algolia/)",

--- a/packages/test/src/connect.jsx
+++ b/packages/test/src/connect.jsx
@@ -10,9 +10,7 @@ export default function connect(mapStateToProps) {
   return (WrappedComponent) =>
     class Connect extends Component {
       static contextTypes = { algoliaStore: storeShape.isRequired };
-      static displayName = `AlgoliaSearchHelperConnect(${getDisplayName(
-        WrappedComponent
-      )})`;
+      static displayName = `AlgoliaSearchHelperConnect(${getDisplayName(WrappedComponent)})`;
 
       constructor(props, context) {
         super();
@@ -21,9 +19,7 @@ export default function connect(mapStateToProps) {
           this.state = mapStateToProps(context.algoliaStore.getState(), props);
 
           this.unsubscribe = context.algoliaStore.subscribe(() => {
-            this.setState(
-              mapStateToProps(context.algoliaStore.getState(), this.props)
-            );
+            this.setState(mapStateToProps(context.algoliaStore.getState(), this.props));
           });
         }
       }
@@ -36,9 +32,7 @@ export default function connect(mapStateToProps) {
 
       // eslint-disable-next-line camelcase
       UNSAFE_componentWillReceiveProps(nextProps) {
-        this.setState(
-          mapStateToProps(this.context.algoliaStore.getState(), nextProps)
-        );
+        this.setState(mapStateToProps(this.context.algoliaStore.getState(), nextProps));
       }
 
       shouldComponentUpdate(nextProps, nextState) {
@@ -46,13 +40,7 @@ export default function connect(mapStateToProps) {
       }
 
       render() {
-        return (
-          <WrappedComponent
-            {...this.props}
-            {...this.state}
-            helper={this.context.algoliaStore.getHelper()}
-          />
-        );
+        return <WrappedComponent {...this.props} {...this.state} helper={this.context.algoliaStore.getHelper()} />;
       }
     };
 }

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -45,6 +45,7 @@
   "include": [
     "index.js",
     "src/*",
-    ".eslintrc.js"
+    ".eslintrc.js",
+    "eslint.config.js"
   ],
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,3 +4,4 @@ set -e # exit when error
 
 cd packages/test
 yarn lint
+yarn lint:legacy

--- a/yarn.lock
+++ b/yarn.lock
@@ -920,6 +920,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rtsao/scc@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@rtsao/scc@npm:1.1.0"
+  checksum: 10c0/b5bcfb0d87f7d1c1c7c0f7693f53b07866ed9fec4c34a97a8c948fb9a7c0082e416ce4d3b60beb4f5e167cbe04cdeefbf6771320f3ede059b9ce91188c409a5b
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.27.8":
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
@@ -1479,7 +1486,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-includes@npm:^3.1.6, array-includes@npm:^3.1.7, array-includes@npm:^3.1.8":
+"array-includes@npm:^3.1.6, array-includes@npm:^3.1.8":
   version: 3.1.8
   resolution: "array-includes@npm:3.1.8"
   dependencies:
@@ -1507,7 +1514,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.findlastindex@npm:^1.2.3":
+"array.prototype.findlastindex@npm:^1.2.5":
   version: 1.2.5
   resolution: "array.prototype.findlastindex@npm:1.2.5"
   dependencies:
@@ -2689,12 +2696,12 @@ __metadata:
 
 "eslint-config-algolia@file:../eslint-config-algolia::locator=test%40workspace%3Apackages%2Ftest":
   version: 23.1.7
-  resolution: "eslint-config-algolia@file:../eslint-config-algolia#../eslint-config-algolia::hash=7517c7&locator=test%40workspace%3Apackages%2Ftest"
+  resolution: "eslint-config-algolia@file:../eslint-config-algolia#../eslint-config-algolia::hash=958b66&locator=test%40workspace%3Apackages%2Ftest"
   peerDependencies:
     "@stylistic/eslint-plugin": ^2.6.4
     eslint: ^5.16.0 || ^6.8.0 || ^7.2.0 || ^8.0.0
     prettier: ^3.0.0
-  checksum: 10c0/4d4ebce9aadd7033ae5c45903c0f1ab4d2555714e807cd4fe3ff398404a4634b52e2d44408bf1e50fc43e8b5d20d9ede53dd6f21a61f7c2794fe1d90fa5f4a1e
+  checksum: 10c0/2a429dc509a7f02eadcfe1a2f06a7dee59d68580dcaea4510c4d7270cd38e360ca949eafa30747a6b7170a06878db005a4e1bc584d36522e365825c63c01977e
   languageName: node
   linkType: hard
 
@@ -2709,7 +2716,7 @@ __metadata:
     "@stylistic/eslint-plugin": "npm:2.7.2"
     eslint: "npm:8.57.0"
     eslint-config-prettier: "npm:8.10.0"
-    eslint-plugin-import: "npm:2.29.1"
+    eslint-plugin-import: "npm:2.31.0"
     eslint-plugin-jest: "npm:28.8.2"
     eslint-plugin-jsdoc: "npm:50.2.2"
     eslint-plugin-jsx-a11y: "npm:6.9.0"
@@ -2747,42 +2754,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-module-utils@npm:^2.8.0":
-  version: 2.8.2
-  resolution: "eslint-module-utils@npm:2.8.2"
+"eslint-module-utils@npm:^2.12.0":
+  version: 2.12.0
+  resolution: "eslint-module-utils@npm:2.12.0"
   dependencies:
     debug: "npm:^3.2.7"
   peerDependenciesMeta:
     eslint:
       optional: true
-  checksum: 10c0/98c5ca95db75507b148c05d157b287116c677bfc9ca6bef4d5455c8b199eb2c35b9204a15ca7a3497085daef8ca3a3f579bd9e753ad4ad4df6256e4ef1107c51
+  checksum: 10c0/4d8b46dcd525d71276f9be9ffac1d2be61c9d54cc53c992e6333cf957840dee09381842b1acbbb15fc6b255ebab99cd481c5007ab438e5455a14abe1a0468558
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:2.29.1":
-  version: 2.29.1
-  resolution: "eslint-plugin-import@npm:2.29.1"
+"eslint-plugin-import@npm:2.31.0":
+  version: 2.31.0
+  resolution: "eslint-plugin-import@npm:2.31.0"
   dependencies:
-    array-includes: "npm:^3.1.7"
-    array.prototype.findlastindex: "npm:^1.2.3"
+    "@rtsao/scc": "npm:^1.1.0"
+    array-includes: "npm:^3.1.8"
+    array.prototype.findlastindex: "npm:^1.2.5"
     array.prototype.flat: "npm:^1.3.2"
     array.prototype.flatmap: "npm:^1.3.2"
     debug: "npm:^3.2.7"
     doctrine: "npm:^2.1.0"
     eslint-import-resolver-node: "npm:^0.3.9"
-    eslint-module-utils: "npm:^2.8.0"
-    hasown: "npm:^2.0.0"
-    is-core-module: "npm:^2.13.1"
+    eslint-module-utils: "npm:^2.12.0"
+    hasown: "npm:^2.0.2"
+    is-core-module: "npm:^2.15.1"
     is-glob: "npm:^4.0.3"
     minimatch: "npm:^3.1.2"
-    object.fromentries: "npm:^2.0.7"
-    object.groupby: "npm:^1.0.1"
-    object.values: "npm:^1.1.7"
+    object.fromentries: "npm:^2.0.8"
+    object.groupby: "npm:^1.0.3"
+    object.values: "npm:^1.2.0"
     semver: "npm:^6.3.1"
+    string.prototype.trimend: "npm:^1.0.8"
     tsconfig-paths: "npm:^3.15.0"
   peerDependencies:
-    eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-  checksum: 10c0/5f35dfbf4e8e67f741f396987de9504ad125c49f4144508a93282b4ea0127e052bde65ab6def1f31b6ace6d5d430be698333f75bdd7dca3bc14226c92a083196
+    eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
+  checksum: 10c0/e21d116ddd1900e091ad120b3eb68c5dd5437fe2c930f1211781cd38b246f090a6b74d5f3800b8255a0ed29782591521ad44eb21c5534960a8f1fb4040fd913a
   languageName: node
   linkType: hard
 
@@ -3851,7 +3860,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.13.0, is-core-module@npm:^2.13.1":
+"is-core-module@npm:^2.13.0, is-core-module@npm:^2.15.1":
   version: 2.15.1
   resolution: "is-core-module@npm:2.15.1"
   dependencies:
@@ -5437,7 +5446,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.fromentries@npm:^2.0.7, object.fromentries@npm:^2.0.8":
+"object.fromentries@npm:^2.0.8":
   version: 2.0.8
   resolution: "object.fromentries@npm:2.0.8"
   dependencies:
@@ -5449,7 +5458,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.groupby@npm:^1.0.1":
+"object.groupby@npm:^1.0.3":
   version: 1.0.3
   resolution: "object.groupby@npm:1.0.3"
   dependencies:
@@ -5460,7 +5469,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.values@npm:^1.1.6, object.values@npm:^1.1.7, object.values@npm:^1.2.0":
+"object.values@npm:^1.1.6, object.values@npm:^1.2.0":
   version: 1.2.0
   resolution: "object.values@npm:1.2.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,10 +472,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/regexpp@npm:^4.10.0, @eslint-community/regexpp@npm:^4.6.1":
+"@eslint-community/regexpp@npm:^4.10.0":
   version: 4.11.0
   resolution: "@eslint-community/regexpp@npm:4.11.0"
   checksum: 10c0/0f6328869b2741e2794da4ad80beac55cba7de2d3b44f796a60955b0586212ec75e6b0253291fd4aad2100ad471d1480d8895f2b54f1605439ba4c875e05e523
+  languageName: node
+  linkType: hard
+
+"@eslint-community/regexpp@npm:^4.6.1":
+  version: 4.11.1
+  resolution: "@eslint-community/regexpp@npm:4.11.1"
+  checksum: 10c0/fbcc1cb65ef5ed5b92faa8dc542e035269065e7ebcc0b39c81a4fe98ad35cfff20b3c8df048641de15a7757e07d69f85e2579c1a5055f993413ba18c055654f8
   languageName: node
   linkType: hard
 
@@ -2696,12 +2703,12 @@ __metadata:
 
 "eslint-config-algolia@file:../eslint-config-algolia::locator=test%40workspace%3Apackages%2Ftest":
   version: 23.1.7
-  resolution: "eslint-config-algolia@file:../eslint-config-algolia#../eslint-config-algolia::hash=c9b0a9&locator=test%40workspace%3Apackages%2Ftest"
+  resolution: "eslint-config-algolia@file:../eslint-config-algolia#../eslint-config-algolia::hash=10d83a&locator=test%40workspace%3Apackages%2Ftest"
   peerDependencies:
     "@stylistic/eslint-plugin": ^2.6.4
     eslint: ^5.16.0 || ^6.8.0 || ^7.2.0 || ^8.0.0
     prettier: ^3.0.0
-  checksum: 10c0/52e255cbb897f2d6617c9cb9b7d98c0bd2aab758fa50f4867a560b11e27d122f5c597391cdc16317bfa6c05c5ea6ca381427a6e2f43270e52b42928b9e533cc2
+  checksum: 10c0/554f516710b5b0838a348c7b58aeed7f34ea7956f9b16313f532dee0973eb0915f0e5d0851edf96e5a2e577e441091757240cba98a2a3d85c78843ca307b9117
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2696,12 +2696,12 @@ __metadata:
 
 "eslint-config-algolia@file:../eslint-config-algolia::locator=test%40workspace%3Apackages%2Ftest":
   version: 23.1.7
-  resolution: "eslint-config-algolia@file:../eslint-config-algolia#../eslint-config-algolia::hash=958b66&locator=test%40workspace%3Apackages%2Ftest"
+  resolution: "eslint-config-algolia@file:../eslint-config-algolia#../eslint-config-algolia::hash=c9b0a9&locator=test%40workspace%3Apackages%2Ftest"
   peerDependencies:
     "@stylistic/eslint-plugin": ^2.6.4
     eslint: ^5.16.0 || ^6.8.0 || ^7.2.0 || ^8.0.0
     prettier: ^3.0.0
-  checksum: 10c0/2a429dc509a7f02eadcfe1a2f06a7dee59d68580dcaea4510c4d7270cd38e360ca949eafa30747a6b7170a06878db005a4e1bc584d36522e365825c63c01977e
+  checksum: 10c0/52e255cbb897f2d6617c9cb9b7d98c0bd2aab758fa50f4867a560b11e27d122f5c597391cdc16317bfa6c05c5ea6ca381427a6e2f43270e52b42928b9e533cc2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -503,6 +503,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/js@npm:9.11.1":
+  version: 9.11.1
+  resolution: "@eslint/js@npm:9.11.1"
+  checksum: 10c0/22916ef7b09c6f60c62635d897c66e1e3e38d90b5a5cf5e62769033472ecbcfb6ec7c886090a4b32fe65d6ce371da54384e46c26a899e38184dfc152c6152f7b
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.14":
   version: 0.11.14
   resolution: "@humanwhocodes/config-array@npm:0.11.14"
@@ -2682,12 +2689,12 @@ __metadata:
 
 "eslint-config-algolia@file:../eslint-config-algolia::locator=test%40workspace%3Apackages%2Ftest":
   version: 23.1.7
-  resolution: "eslint-config-algolia@file:../eslint-config-algolia#../eslint-config-algolia::hash=1b945a&locator=test%40workspace%3Apackages%2Ftest"
+  resolution: "eslint-config-algolia@file:../eslint-config-algolia#../eslint-config-algolia::hash=7517c7&locator=test%40workspace%3Apackages%2Ftest"
   peerDependencies:
     "@stylistic/eslint-plugin": ^2.6.4
     eslint: ^5.16.0 || ^6.8.0 || ^7.2.0 || ^8.0.0
     prettier: ^3.0.0
-  checksum: 10c0/803e65bc961c7c7489d401759e387d442bc60f13fdbe1231210642ad81b2b81ae5a5e099f2e554f80a39a1bd8dad7966b20ec47c7d4e5055ec56c117670550a3
+  checksum: 10c0/4d4ebce9aadd7033ae5c45903c0f1ab4d2555714e807cd4fe3ff398404a4634b52e2d44408bf1e50fc43e8b5d20d9ede53dd6f21a61f7c2794fe1d90fa5f4a1e
   languageName: node
   linkType: hard
 
@@ -2698,6 +2705,7 @@ __metadata:
     "@babel/core": "npm:7.25.2"
     "@babel/eslint-parser": "npm:7.25.1"
     "@eslint-community/eslint-plugin-eslint-comments": "npm:4.4.0"
+    "@eslint/js": "npm:9.11.1"
     "@stylistic/eslint-plugin": "npm:2.7.2"
     eslint: "npm:8.57.0"
     eslint-config-prettier: "npm:8.10.0"
@@ -2708,6 +2716,7 @@ __metadata:
     eslint-plugin-prettier: "npm:5.2.1"
     eslint-plugin-react: "npm:7.35.0"
     eslint-plugin-react-hooks: "npm:4.6.2"
+    globals: "npm:15.10.0"
     prettier: "npm:3.3.3"
   peerDependencies:
     "@stylistic/eslint-plugin": ^2.6.4
@@ -3458,6 +3467,13 @@ __metadata:
     once: "npm:^1.3.0"
     path-is-absolute: "npm:^1.0.0"
   checksum: 10c0/65676153e2b0c9095100fe7f25a778bf45608eeb32c6048cf307f579649bcc30353277b3b898a3792602c65764e5baa4f643714dfbdfd64ea271d210c7a425fe
+  languageName: node
+  linkType: hard
+
+"globals@npm:15.10.0":
+  version: 15.10.0
+  resolution: "globals@npm:15.10.0"
+  checksum: 10c0/fef8f320e88f01f1492fef1b04b056908e1f6726eeaffe3bca03247237300c2d86e71585ee641b62ba71460a6eaff0d6ca7fca284e61bd1b3f833c7ad68b160a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Introduce flat configs ([blog](https://eslint.org/blog/2022/08/new-config-system-part-2/), [doc](https://eslint.org/docs/latest/use/configure/configuration-files)), required to migrate to ESLint 9 (#342).
Migration guide: https://eslint.org/docs/latest/use/configure/migration-guide

To keep our config compatible with legacy versions, I've created new configs in a separate `flat/` directory.
You can see the new usage in the updated README or in the `packages/test/eslint.config.js` files:

```js
// eslint.config.js
const algolia = require('eslint-config-algolia/flat/base');
module.exports = [
  ...algolia,
];
```

### Notes

I've tried to keep changes minimal, configs in the `flat/` dir are meant to be a simple port.
A lot of plugins already expose ways to work with flat configs, I simply followed their doc, for example:
- https://github.com/prettier/eslint-plugin-prettier?tab=readme-ov-file#configuration-new-eslintconfigjs
- https://github.com/jsx-eslint/eslint-plugin-react?tab=readme-ov-file#flat-configs

Edit: FIXED in [2.31.0](https://github.com/import-js/eslint-plugin-import/releases/tag/v2.31.0)  ~~Only the `import` plugin is not fully compatible and I had to disable `import/no-named-as-default` for now.~~

I've been able to reuse the rules from the `rules/` dir by just deleting the deprecated properties:
- `plugins` is now moved at the top level
- `overrides` is now an additional entry of the flat config

### Changes

- new flat configs in the `flat/` dir
- new `eslint.config.js` files
- tests are run with both legacy and flat configs
- new dependencies required: `@eslint/js` and `global`

#### Refs

- `env` moved to `languageOptions`: https://eslint.org/docs/latest/use/configure/migration-guide#configuring-language-options
- plugins: https://eslint.org/docs/latest/use/configure/migration-guide#importing-plugins-and-custom-parsers
- `parser` moved to `languageOptions`: https://eslint.org/docs/latest/use/configure/migration-guide#custom-parsers

---
SFCC-391