### PR TITLE
fix: correctly import jest flat configs

### DIFF
--- a/packages/eslint-config-algolia/flat/jest.js
+++ b/packages/eslint-config-algolia/flat/jest.js
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-commonjs */
 const jestPlugin = require('eslint-plugin-jest');
-const globals = require('globals');
 
 const jestRules = require('../rules/jest');
 
@@ -8,11 +7,8 @@ module.exports = [
   jestRules,
   {
     ...jestPlugin.configs['flat/recommended'],
+  },
+  {
     ...jestPlugin.configs['flat/style'],
-    languageOptions: {
-      globals: {
-        ...globals.jest,
-      },
-    },
   },
 ];

--- a/packages/eslint-config-algolia/flat/jest.js
+++ b/packages/eslint-config-algolia/flat/jest.js
@@ -4,11 +4,11 @@ const jestPlugin = require('eslint-plugin-jest');
 const jestRules = require('../rules/jest');
 
 module.exports = [
-  jestRules,
   {
     ...jestPlugin.configs['flat/recommended'],
   },
   {
     ...jestPlugin.configs['flat/style'],
   },
+  jestRules,
 ];

--- a/packages/test/eslint.config.js
+++ b/packages/test/eslint.config.js
@@ -10,10 +10,16 @@ module.exports = [
   ...algoliaReact,
   ...algoliaJest,
   {
+    files: ['**/*.{js,ts,jsx,tsx}'],
+  },
+  {
     languageOptions: {
       parserOptions: {
         project: 'tsconfig.json',
       },
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
     },
   },
 ];

--- a/packages/test/eslint.config.js
+++ b/packages/test/eslint.config.js
@@ -10,9 +10,6 @@ module.exports = [
   ...algoliaReact,
   ...algoliaJest,
   {
-    files: ['**/*.{js,ts,jsx,tsx}'],
-  },
-  {
     languageOptions: {
       parserOptions: {
         project: 'tsconfig.json',

--- a/packages/test/src/connect.jsx
+++ b/packages/test/src/connect.jsx
@@ -30,7 +30,6 @@ export default function connect(mapStateToProps) {
         }
       }
 
-      // eslint-disable-next-line camelcase
       UNSAFE_componentWillReceiveProps(nextProps) {
         this.setState(mapStateToProps(this.context.algoliaStore.getState(), nextProps));
       }

--- a/packages/test/src/simple.test.js
+++ b/packages/test/src/simple.test.js
@@ -1,0 +1,17 @@
+describe('simple tests', () => {
+  // Test a rule from the Algolia config
+  // eslint-disable-next-line jest/consistent-test-it
+  test('should do simple maths', () => {
+    expect(Math.pow(2, 8)).toBe(256);
+  });
+
+  // Test a rule from the recommended config (https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-commented-out-tests.md)
+  // eslint-disable-next-line jest/no-commented-out-tests
+  // it('foo', () => {});
+
+  it('should do simple comparison', () => {
+    // Test a rule from the style config (https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-to-be.md)
+    // eslint-disable-next-line jest/prefer-to-be
+    expect(0).toEqual(0);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2861,12 +2861,12 @@ __metadata:
 
 "eslint-config-algolia@file:../eslint-config-algolia::locator=test%40workspace%3Apackages%2Ftest":
   version: 23.2.0
-  resolution: "eslint-config-algolia@file:../eslint-config-algolia#../eslint-config-algolia::hash=792dff&locator=test%40workspace%3Apackages%2Ftest"
+  resolution: "eslint-config-algolia@file:../eslint-config-algolia#../eslint-config-algolia::hash=5dc416&locator=test%40workspace%3Apackages%2Ftest"
   peerDependencies:
     "@stylistic/eslint-plugin": ^2.6.4
     eslint: ^5.16.0 || ^6.8.0 || ^7.2.0 || ^8.0.0 || ^9.0.0
     prettier: ^3.0.0
-  checksum: 10c0/d01694d1a43cfce890f3f5b6dccad74e1e8ef5714f2a820d7f44caa6f8c36d58d51d33979a019d3dfcbc4c4bea272f3ab1b96a9d51f161e318c15380065dccd4
+  checksum: 10c0/a9d3f9824735bfa89570b1bb4ad1df4027ca0f4cba977edb376ad4a812253560a26a94c2c05cfef3ec4ce8d3bb16385ff91e7cf156e1b651396eed25ec3d3399
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I figured out that Jest flat configs are containing the following:

```
{
  plugins: { jest: plugin },
  languageOptions: { globals },
  rules,
}
```
https://github.com/jest-community/eslint-plugin-jest/blob/98087f9bb27082f9fbda59a56c65536fb9d8a0dc/src/index.ts#L95

So spreading the `style` config in the same config object than the `recommended` config was actually overriding it.

### Tests

I've added a simple test file with some disabled rules, and set `reportUnusedDisableDirectives` to error so it will report if those rules are not included anymore.