### PR TITLE
chore: fix package bugs metadata

### DIFF
--- a/packages/eslint-config-algolia/package.json
+++ b/packages/eslint-config-algolia/package.json
@@ -20,7 +20,7 @@
   "author": "Algolia, Inc.",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/algolia/eslint-config-algolia"
+    "url": "https://github.com/algolia/eslint-config-algolia/issues"
   },
   "homepage": "https://github.com/algolia/eslint-config-algolia",
   "devDependencies": {


### PR DESCRIPTION
## Summary

- update `eslint-config-algolia` package metadata so `bugs.url` points directly to the GitHub issue tracker
- keep repository, homepage, runtime code, dependencies, exports, and version unchanged

## Why

The currently published `eslint-config-algolia@24.0.0` npm metadata points `bugs.url` at the repository root. Package managers and registry consumers conventionally use `bugs.url` as the direct issue tracker link, so this adjusts it to `https://github.com/algolia/eslint-config-algolia/issues`.

## Validation

- `node` package metadata assertion for name, version, license, homepage, and `bugs.url`
- `npm view eslint-config-algolia name version repository bugs homepage license --json`
- `cd packages/eslint-config-algolia && npm pack --dry-run --ignore-scripts --json`
- `git diff --check HEAD~1..HEAD`